### PR TITLE
ENH: Add Linux aarch64, ppc64le and macOS arm64 builds

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,6 +12,14 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_:
+        CONFIG: linux_aarch64_
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_ppc64le_:
+        CONFIG: linux_ppc64le_
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -11,6 +11,9 @@ jobs:
       osx_64_:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
+      osx_arm64_:
+        CONFIG: osx_arm64_
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,0 +1,20 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+curl:
+- '8'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,0 +1,20 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+curl:
+- '8'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+target_platform:
+- linux-ppc64le

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,0 +1,22 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+curl:
+- '8'
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '18'
+macos_machine:
+- arm64-apple-darwin20.0.0
+target_platform:
+- osx-arm64

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -48,6 +48,9 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+fi
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -89,6 +89,10 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     /bin/bash
 else
 
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    fi
+
     conda-build ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \

--- a/README.md
+++ b/README.md
@@ -42,10 +42,31 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=24381&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastjet-contrib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=24381&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastjet-contrib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=24381&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastjet-contrib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=24381&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/fastjet-contrib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
                 </a>
               </td>
             </tr>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,14 @@
-github:
-  branch_name: main
-  tooling_branch_name: main
+build_platform:
+  linux_aarch64: linux_64
+  linux_ppc64le: linux_64
+  osx_arm64: osx_64
 conda_build:
   error_overlinking: true
 conda_forge_output_validation: true
+github:
+  branch_name: main
+  tooling_branch_name: main
+provider:
+  linux_aarch64: default
+  linux_ppc64le: default
+test: native_and_emulated

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ outputs:
         - {{ pin_subpackage('fastjet-contrib', max_pin='x.x') }}
       script:
         # FIXME: Avoid install_name_tool 'larger updated load commands do not fit' error
-        - export LDFLAGS="${LDFLAGS} -headerpad_max_install_names"  # [osx and arm64]
+        - sed -i 's/DPIC $(CXXFLAGS)/DPIC $(CXXFLAGS) -Wl,-headerpad_max_install_names/g' Makefile.in  # [osx and arm64]
 
         # Get an updated config.sub and config.guess
         - cp $BUILD_PREFIX/share/gnuconfig/config.* .
@@ -65,6 +65,7 @@ outputs:
         - make
         - pkg-config
         - gnuconfig
+        - sed  # [osx and arm64]
       host:
         - fastjet-cxx
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,9 @@ package:
 source:
   url: https://fastjet.hepforge.org/contrib/downloads/fjcontrib-{{ version }}.tar.gz
   sha256: fc31544424dece0d0676ea2433ad1e96fd9db82920bc7a7ef6294ce94e659d6e
+  patches:
+    # FIXME: Avoid install_name_tool 'larger updated load commands do not fit' error
+    - use-headerpad_max_install_names-linker-option.patch  # [osx and arm64]
 
 build:
   number: 1
@@ -22,9 +25,6 @@ outputs:
       run_exports:
         - {{ pin_subpackage('fastjet-contrib', max_pin='x.x') }}
       script:
-        # FIXME: Avoid install_name_tool 'larger updated load commands do not fit' error
-        - sed -i 's/DPIC $(CXXFLAGS)/DPIC $(CXXFLAGS) -Wl,-headerpad_max_install_names/g' Makefile.in  # [osx and arm64]
-
         # Get an updated config.sub and config.guess
         - cp $BUILD_PREFIX/share/gnuconfig/config.* .
         - ./configure --help
@@ -65,7 +65,6 @@ outputs:
         - make
         - pkg-config
         - gnuconfig
-        - sed  # [osx and arm64]
       host:
         - fastjet-cxx
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,7 +62,6 @@ outputs:
         - make
         - pkg-config
         - gnuconfig
-        - fastjet-cxx  # [build_platform != target_platform]
       host:
         - fastjet-cxx
       run:
@@ -100,7 +99,6 @@ outputs:
         - make
         - pkg-config
         - gnuconfig
-        - fastjet-cxx  # [build_platform != target_platform]
       host:
         - fastjet-cxx
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,9 @@ outputs:
       run_exports:
         - {{ pin_subpackage('fastjet-contrib', max_pin='x.x') }}
       script:
+        # FIXME: Avoid install_name_tool 'larger updated load commands do not fit' error
+        - export LDFLAGS="${LDFLAGS} -headerpad_max_install_names"  # [osx and arm64]
+
         # Get an updated config.sub and config.guess
         - cp $BUILD_PREFIX/share/gnuconfig/config.* .
         - ./configure --help

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: fc31544424dece0d0676ea2433ad1e96fd9db82920bc7a7ef6294ce94e659d6e
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ name }}

--- a/recipe/use-headerpad_max_install_names-linker-option.patch
+++ b/recipe/use-headerpad_max_install_names-linker-option.patch
@@ -1,0 +1,40 @@
+From 945813f1414a09c77cde49e95df9d3c13c0fc313 Mon Sep 17 00:00:00 2001
+From: Matthew Feickert <matthew.feickert@cern.ch>
+Date: Fri, 13 Dec 2024 23:48:02 -0700
+Subject: [PATCH] fix: Use -headerpad_max_install_names to avoid
+ install_name_tool error
+
+* Use '-Wl,-headerpad_max_install_names' linker option to avoid the macOS arm64
+  error:
+
+install_name_tool: changing install names or rpaths can't be redone for:
+$PREFIX/lib/libfastjetcontribfragile.dylib (for architecture arm64) because
+larger updated load commands do not fit (the program must be relinked, and
+you may need to use -headerpad or -headerpad_max_install_names)
+
+  From 'man ld' on macOS:
+
+-headerpad_max_install_names
+Automatically adds space for future expansion of load commands such that all
+paths could expand to MAXPATHLEN. Only useful if intend to run
+install_name_tool to alter the load commands later.
+---
+ Makefile.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index 7f793cb..4654ef9 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -55,7 +55,7 @@ fragile-shared: libfastjetcontribfragile.@DYNLIBEXT@
+ 
+ fragile_SHARED_SRC_LIST=@FRAGILE_SHARED_SRC_LIST@
+ libfastjetcontribfragile.@DYNLIBEXT@: $(fragile_SHARED_SRC_LIST)
+-	$(CXX) @DYNLIBOPT@ -fPIC -DPIC $(CXXFLAGS) `$(FASTJETCONFIG) --cxxflags --libs` $(fragile_SHARED_SRC_LIST) -o libfastjetcontribfragile.@DYNLIBEXT@
++	$(CXX) @DYNLIBOPT@ -fPIC -DPIC $(CXXFLAGS) -Wl,-headerpad_max_install_names `$(FASTJETCONFIG) --cxxflags --libs` $(fragile_SHARED_SRC_LIST) -o libfastjetcontribfragile.@DYNLIBEXT@
+ 
+ fragile-shared-install: fragile-shared
+ 	utils/install-sh -c -m 755 libfastjetcontribfragile.@DYNLIBEXT@ $(PREFIX)/lib
+-- 
+2.47.1
+


### PR DESCRIPTION
* Enable builds for platforms: `linux_aarch64`, `linux_ppc64le`, `osx_arm64`.
   - Remove `fastjet-cxx` as a '`build`' requirement for cross-compile builds, as it should be a '`host`' requirement only.
   - Add patch to use `-Wl,-headerpad_max_install_names` linker option for `osx-arm64` builds to avoid the error:

`install_name_tool`: changing install names or rpaths can't be redone for: `$PREFIX/lib/libfastjetcontribfragile.dylib` (for architecture arm64) because larger updated load commands do not fit (the program must be relinked, and you may need to use `-headerpad` or `-headerpad_max_install_names`)

* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
