### PR TITLE
FIX: Use grep to update Centauro header paths

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: fc31544424dece0d0676ea2433ad1e96fd9db82920bc7a7ef6294ce94e659d6e
   patches:
     # FIXME: Avoid install_name_tool 'larger updated load commands do not fit' error
-    - use-headerpad_max_install_names-linker-option.patch  # [osx and arm64]
+    - use-headerpad_max_install_names-linker-option.patch  # [osx]
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: fc31544424dece0d0676ea2433ad1e96fd9db82920bc7a7ef6294ce94e659d6e
   patches:
     # FIXME: Avoid install_name_tool 'larger updated load commands do not fit' error
-    - use-headerpad_max_install_names-linker-option.patch  # [osx]
+    - use-headerpad_max_install_names-linker-option.patch  # [osx and arm64]
 
 build:
   number: 1

--- a/recipe/run_test_shared.sh
+++ b/recipe/run_test_shared.sh
@@ -75,7 +75,7 @@ curl -sL https://fastjet.hepforge.org/contrib/downloads/fjcontrib-"${PKG_VERSION
 cd fjcontrib-"${PKG_VERSION}"
 
 cd Centauro
-grep -rl '#include "Centauro.hh"' | xargs sed -i 's|#include "Centauro.hh"|#include "fastjet/contrib/Centauro.hh"|g' Centauro.cc
+grep -rl '#include "Centauro.hh"' | xargs sed -i 's|#include "Centauro.hh"|#include "fastjet/contrib/Centauro.hh"|g'
 $CXX example.cc -o example $CXXFLAGS $LDFLAGS -lfastjetcontribfragile -lfastjet
 ./example < ../data/single-event.dat &> Centauro_example_output.txt
 

--- a/recipe/run_test_static.sh
+++ b/recipe/run_test_static.sh
@@ -75,7 +75,7 @@ curl -sL https://fastjet.hepforge.org/contrib/downloads/fjcontrib-"${PKG_VERSION
 cd fjcontrib-"${PKG_VERSION}"
 
 cd Centauro
-grep -rl '#include "Centauro.hh"' | xargs sed -i 's|#include "Centauro.hh"|#include "fastjet/contrib/Centauro.hh"|g' Centauro.cc
+grep -rl '#include "Centauro.hh"' | xargs sed -i 's|#include "Centauro.hh"|#include "fastjet/contrib/Centauro.hh"|g'
 $CXX example.cc -o example $CXXFLAGS $LDFLAGS -lCentauro -lfastjet
 ./example < ../data/single-event.dat &> Centauro_example_output.txt
 


### PR DESCRIPTION
* Remove particular target file of Centauro.cc.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
   - This fix is for the tests only, not the build, so no need to push new files.
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
