### PR TITLE
fix/build: move to -split output for non-fragile build

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-fastjet--contrib-green.svg)](https://anaconda.org/conda-forge/fastjet-contrib) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/fastjet-contrib.svg)](https://anaconda.org/conda-forge/fastjet-contrib) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/fastjet-contrib.svg)](https://anaconda.org/conda-forge/fastjet-contrib) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/fastjet-contrib.svg)](https://anaconda.org/conda-forge/fastjet-contrib) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-fastjet--contrib--static-green.svg)](https://anaconda.org/conda-forge/fastjet-contrib-static) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/fastjet-contrib-static.svg)](https://anaconda.org/conda-forge/fastjet-contrib-static) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/fastjet-contrib-static.svg)](https://anaconda.org/conda-forge/fastjet-contrib-static) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/fastjet-contrib-static.svg)](https://anaconda.org/conda-forge/fastjet-contrib-static) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-fastjet--contrib--split-green.svg)](https://anaconda.org/conda-forge/fastjet-contrib-split) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/fastjet-contrib-split.svg)](https://anaconda.org/conda-forge/fastjet-contrib-split) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/fastjet-contrib-split.svg)](https://anaconda.org/conda-forge/fastjet-contrib-split) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/fastjet-contrib-split.svg)](https://anaconda.org/conda-forge/fastjet-contrib-split) |
 
 Installing fastjet-contrib
 ==========================
@@ -94,16 +94,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `fastjet-contrib, fastjet-contrib-static` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `fastjet-contrib, fastjet-contrib-split` can be installed with `conda`:
 
 ```
-conda install fastjet-contrib fastjet-contrib-static
+conda install fastjet-contrib fastjet-contrib-split
 ```
 
 or with `mamba`:
 
 ```
-mamba install fastjet-contrib fastjet-contrib-static
+mamba install fastjet-contrib fastjet-contrib-split
 ```
 
 It is possible to list all of the versions of `fastjet-contrib` available on your platform with `conda`:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -16,7 +16,7 @@ source:
     # - 0002-required-source-changes-for-windows-build.patch
 
 build:
-  number: 2
+  number: 3
   skip: win
 
 outputs:
@@ -25,11 +25,10 @@ outputs:
 
     build:
       script:
-        - cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PREFIX} -DFASTJETCONTRIB_ENABLE_FRAGILELIB=ON
         - if: unix
-          then: cmake "${CMAKE_ARGS}" -DCMAKE_INSTALL_PREFIX="${PREFIX}" -S . -B build
+          then: cmake "${CMAKE_ARGS}" -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DFASTJETCONTRIB_ENABLE_FRAGILELIB=ON -S . -B build 
         - if: win
-          then: cmake %CMAKE_ARGS% -S . -B build
+          then: cmake %CMAKE_ARGS% -DFASTJETCONTRIB_ENABLE_FRAGILELIB=ON -S . -B build
         - cmake -LH build
         - if: unix
           then: cmake --build build --parallel="${CPU_COUNT}"
@@ -124,15 +123,14 @@ outputs:
 
 
   - package:
-      name: ${{ name }}-static
+      name: ${{ name }}-split
 
     build:
       script:
-        - cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PREFIX} -DFASTJETCONTRIB_ENABLE_FRAGILELIB=OFF
         - if: unix
-          then: cmake "${CMAKE_ARGS}" -DCMAKE_INSTALL_PREFIX="${PREFIX}" -S . -B build
+          then: cmake "${CMAKE_ARGS}" -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DFASTJETCONTRIB_ENABLE_FRAGILELIB=OFF -S . -B build 
         - if: win
-          then: cmake %CMAKE_ARGS% -S . -B build
+          then: cmake %CMAKE_ARGS% -DFASTJETCONTRIB_ENABLE_FRAGILELIB=OFF -S . -B build
         - cmake -LH build
         - if: unix
           then: cmake --build build --parallel="${CPU_COUNT}"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -128,9 +128,9 @@ outputs:
     build:
       script:
         - if: unix
-          then: cmake "${CMAKE_ARGS}" -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DFASTJETCONTRIB_ENABLE_FRAGILELIB=OFF -S . -B build 
+          then: cmake "${CMAKE_ARGS}" -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DCMAKE_BUILD_TYPE=Release -DFASTJETCONTRIB_ENABLE_FRAGILELIB=OFF -S . -B build 
         - if: win
-          then: cmake %CMAKE_ARGS% -DFASTJETCONTRIB_ENABLE_FRAGILELIB=OFF -S . -B build
+          then: cmake %CMAKE_ARGS% -DCMAKE_BUILD_TYPE=Release -DFASTJETCONTRIB_ENABLE_FRAGILELIB=OFF -S . -B build
         - cmake -LH build
         - if: unix
           then: cmake --build build --parallel="${CPU_COUNT}"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -26,9 +26,9 @@ outputs:
     build:
       script:
         - if: unix
-          then: cmake "${CMAKE_ARGS}" -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DFASTJETCONTRIB_ENABLE_FRAGILELIB=ON -S . -B build 
+          then: cmake "${CMAKE_ARGS}" -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DCMAKE_BUILD_TYPE=Release -DFASTJETCONTRIB_ENABLE_FRAGILELIB=ON -S . -B build 
         - if: win
-          then: cmake %CMAKE_ARGS% -DFASTJETCONTRIB_ENABLE_FRAGILELIB=ON -S . -B build
+          then: cmake %CMAKE_ARGS% -DCMAKE_BUILD_TYPE=Release -DFASTJETCONTRIB_ENABLE_FRAGILELIB=ON -S . -B build
         - cmake -LH build
         - if: unix
           then: cmake --build build --parallel="${CPU_COUNT}"


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

- use fastjet-contrib-split output
- clean up cmake configure step
