### PR TITLE
fix: comment out patch for windows build in injected cmake

### DIFF
--- a/recipe/0001-top-level-only-cmake-scripts.patch
+++ b/recipe/0001-top-level-only-cmake-scripts.patch
@@ -35,13 +35,13 @@ index 0000000..c51bd38
 +#set(PROJECT_VERSION_PRERELEASE "")
 +set(PROJECT_VERSION_PRERELEASE "-devel")
 +
-+if(MSVC)
-+  execute_process(COMMAND 
-+                    git apply --whitespace=fix -p0 0001-required-source-changes-for-windows-build.patch
-+                  WORKING_DIRECTORY
-+                    ${CMAKE_CURRENT_SOURCE_DIR}
-+                 )
-+endif()
++#if(MSVC)
++#  execute_process(COMMAND 
++#                    git apply --whitespace=fix -p0 0001-required-source-changes-for-windows-build.patch
++#                  WORKING_DIRECTORY
++#                    ${CMAKE_CURRENT_SOURCE_DIR}
++#                 )
++#endif()
 +
 +#----------------------------------------------------------------------
 +# version information


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Fixes #10 